### PR TITLE
Fix Supabase CLI installation to use official installer

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -60,7 +60,10 @@ jobs:
 
       - name: Install Supabase CLI
         run: |
-          npm install -g supabase
+          # Install Supabase CLI using the official installation method
+          curl -fsSL https://get.supabase.com | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          export PATH="$HOME/.local/bin:$PATH"
           supabase --version
 
       - name: Verify migration files exist
@@ -84,6 +87,7 @@ jobs:
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
+          export PATH="$HOME/.local/bin:$PATH"
           echo "🚀 Linking to Supabase production project..."
           supabase link --project-ref $SUPABASE_PROJECT_REF
 
@@ -101,6 +105,7 @@ jobs:
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
+          export PATH="$HOME/.local/bin:$PATH"
           echo "🔍 Verifying migration deployment..."
           supabase migration list
 


### PR DESCRIPTION
- Replace npm install with curl installer from get.supabase.com
- Set proper PATH for CLI availability in workflow steps
- Use official installation method as recommended by Supabase

🤖 Generated with [Claude Code](https://claude.ai/code)