### PR TITLE
Fix Supabase CLI installation using GitHub releases

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -60,10 +60,11 @@ jobs:
 
       - name: Install Supabase CLI
         run: |
-          # Install Supabase CLI using the official installation method
-          curl -fsSL https://get.supabase.com | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          export PATH="$HOME/.local/bin:$PATH"
+          # Install Supabase CLI using GitHub releases
+          SUPABASE_VERSION="1.207.2"
+          wget -O supabase.tar.gz "https://github.com/supabase/cli/releases/download/v${SUPABASE_VERSION}/supabase_${SUPABASE_VERSION}_linux_amd64.tar.gz"
+          tar -xzf supabase.tar.gz
+          sudo mv supabase /usr/local/bin/
           supabase --version
 
       - name: Verify migration files exist
@@ -87,7 +88,6 @@ jobs:
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
           echo "🚀 Linking to Supabase production project..."
           supabase link --project-ref $SUPABASE_PROJECT_REF
 
@@ -105,7 +105,6 @@ jobs:
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
           echo "🔍 Verifying migration deployment..."
           supabase migration list
 


### PR DESCRIPTION
- Replace broken get.supabase.com URL with direct GitHub release download
- Install CLI globally to /usr/local/bin for reliable access
- Remove PATH exports as CLI is now globally available
- Use stable version 1.207.2 for consistent behavior

🤖 Generated with [Claude Code](https://claude.ai/code)