### PR TITLE
Remove placeholder text from temperature input fields in Log Temperat…

### DIFF
--- a/client/src/pages/temp-logger.tsx
+++ b/client/src/pages/temp-logger.tsx
@@ -689,7 +689,6 @@ export default function TempLogger() {
                                       {...field}
                                       type="number"
                                       step="0.1"
-                                      placeholder="e.g. 2.1"
                                       className="h-11 border-slate-300 dark:border-slate-600 focus:border-blue-500 dark:focus:border-blue-400"
                                       data-testid="input-min-temperature"
                                     />
@@ -712,7 +711,6 @@ export default function TempLogger() {
                                       {...field}
                                       type="number"
                                       step="0.1"
-                                      placeholder="e.g. 7.8"
                                       className="h-11 border-slate-300 dark:border-slate-600 focus:border-blue-500 dark:focus:border-blue-400"
                                       data-testid="input-max-temperature"
                                     />
@@ -735,7 +733,6 @@ export default function TempLogger() {
                                       {...field}
                                       type="number"
                                       step="0.1"
-                                      placeholder="e.g. 4.5"
                                       className="h-11 border-slate-300 dark:border-slate-600 focus:border-blue-500 dark:focus:border-blue-400"
                                       data-testid="input-current-temperature"
                                     />


### PR DESCRIPTION
…ure Reading form

- Remove placeholder="e.g. 2.1" from Min Temp field
- Remove placeholder="e.g. 7.8" from Max Temp field
- Remove placeholder="e.g. 4.5" from Current Temp field
- Clean up form appearance by removing distracting example values
- Maintain all existing functionality, validation, and styling
- Preserve data-testid attributes for testing compatibility
- Improve user experience with cleaner input fields

Temperature fields now appear professional without placeholder distractions.

🤖 Generated with [Claude Code](https://claude.ai/code)