### PR TITLE
Add paid membership tracking fields to users table

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -309,6 +309,9 @@ model users {
   stripe_subscription_id                                  String?
   created_at                                              DateTime?               @default(now()) @db.Timestamp(6)
   updated_at                                              DateTime?               @default(now()) @db.Timestamp(6)
+  paid_member_since                                       DateTime?               @db.Timestamp(6)
+  current_paid_period_start                               DateTime?               @db.Timestamp(6)
+  total_paid_days                                         Int?                    @default(0)
   audit_completions_audit_completions_completed_byTousers audit_completions[]     @relation("audit_completions_completed_byTousers")
   audit_completions_audit_completions_user_idTousers      audit_completions[]     @relation("audit_completions_user_idTousers")
   audit_templates                                         audit_templates[]


### PR DESCRIPTION
Added three new fields to track paid membership duration:
- paid_member_since: When user first became a paid member
- current_paid_period_start: Start of current paid period
- total_paid_days: Running total of days as paid member

Changes applied directly to Railway dev database and schema updated via prisma db pull.

🤖 Generated with [Claude Code](https://claude.ai/code)